### PR TITLE
Fix mappingContentIdentifier

### DIFF
--- a/lib/jskos/identifiers.js
+++ b/lib/jskos/identifiers.js
@@ -46,7 +46,7 @@ function mappingMembers(mapping) {
 }
 
 function mappingContentIdentifier(mapping) {
-  const json = JSON.stringify(mappingContent(mapping), ["from","to","type"])
+  const json = JSON.stringify(mappingContent(mapping), ["from","to","type","memberSet","memberList","memberChoice","uri"])
   return "urn:jskos:mapping:content:" + sha1(json+"\n")
 }
 


### PR DESCRIPTION
Apparently, the property whitelist that is used with JSON.stringify works recursively, meaning that content identifiers are always using empty concept lists. To fix this, `memberSet`, `memberList`, `memberChoice`, and `uri` have to be added to the whitelist.